### PR TITLE
Use Docker CLI instead of Docker action

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -19,4 +19,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: test-results
-          path: $RUNNER_TEMP/artifacts
+          path: ${{ runner.temp }}/artifacts

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -11,9 +11,9 @@ jobs:
         run: mkdir -p "$RUNNER_TEMP/artifacts"
       - name: Run test service
         run: |
-          docker run jclem/playwright-test-service-prototype \
-            --mount source="$RUNNER_TEMP/artifacts",destination=/app/artifacts
-      - run: ls -ahl "$RUNNER_TEMP"
+          docker run -t \
+            --mount type=bind,src="$RUNNER_TEMP/artifacts",dst=/app/artifacts \
+            jclem/playwright-test-service-prototype
       - name: upload artifacts
         if: ${{ always() }} # could be if: ${{ failure() }} to only upload artifacts when previous step of running playwright tests fails
         uses: actions/upload-artifact@v2

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -9,7 +9,8 @@ jobs:
         uses: docker pull jclem/playwright-test-service-prototype:latest
       - name: Create output directory
         run: mkdir -p "$RUNNER_TEMP/artifacts"
-      - name: |
+      - name: Run test service
+        run: |
           docker run jclem/playwright-test-service-prototype \
             --mount source="$RUNNER_TEMP/artifacts",destination=/app/artifacts
       - name: upload artifacts

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -5,11 +5,16 @@ jobs:
     runs-on: ubuntu-latest
     name: Runs e2e tests with Playwright
     steps:
-    - name: Playwright test suite
-      uses: jclem/playwright-test-service-prototype@master
-    - name: upload artifacts
-      if: ${{ always() }} # could be if: ${{ failure() }} to only upload artifacts when previous step of running playwright tests fails
-      uses: actions/upload-artifact@v2
-      with:
-        name: test-results
-        path: /app/artifact/results.json # or path/to/artifact
+      - name: Pull test service container
+        uses: docker pull jclem/playwright-test-service-prototype:latest
+      - name: Create output directory
+        run: mkdir -p "$RUNNER_TEMP/artifacts"
+      - name: |
+          docker run jclem/playwright-test-service-prototype \
+            --mount source="$RUNNER_TEMP/artifacts",destination=/app/artifacts
+      - name: upload artifacts
+        if: ${{ always() }} # could be if: ${{ failure() }} to only upload artifacts when previous step of running playwright tests fails
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-results
+          path: '$RUNNER_TEMP/artifact/results.json'

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -13,7 +13,7 @@ jobs:
         run: |
           docker run -t \
             --mount type=bind,src="$RUNNER_TEMP/artifacts",dst=/app/artifacts \
-            jclem/playwright-test-service-prototype
+            SophieDeBenedetto/playwright-test-service-prototype
       - name: upload artifacts
         if: ${{ always() }} # could be if: ${{ failure() }} to only upload artifacts when previous step of running playwright tests fails
         uses: actions/upload-artifact@v2

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -6,7 +6,7 @@ jobs:
     name: Runs e2e tests with Playwright
     steps:
       - name: Pull test service container
-        uses: docker pull jclem/playwright-test-service-prototype:latest
+        run: docker pull jclem/playwright-test-service-prototype:latest
       - name: Create output directory
         run: mkdir -p "$RUNNER_TEMP/artifacts"
       - name: Run test service

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -18,4 +18,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: test-results
-          path: '$RUNNER_TEMP/artifact/results.json'
+          path: '$RUNNER_TEMP/artifacts/results.json'

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -13,9 +13,10 @@ jobs:
         run: |
           docker run jclem/playwright-test-service-prototype \
             --mount source="$RUNNER_TEMP/artifacts",destination=/app/artifacts
+      - run: ls -ahl "$RUNNER_TEMP"
       - name: upload artifacts
         if: ${{ always() }} # could be if: ${{ failure() }} to only upload artifacts when previous step of running playwright tests fails
         uses: actions/upload-artifact@v2
         with:
           name: test-results
-          path: '$RUNNER_TEMP/artifacts/results.json'
+          path: $RUNNER_TEMP/artifacts

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,4 +1,4 @@
-on: [push]
+on: [push, workflow_dispatch]
 
 jobs:
   e2e_tests:
@@ -6,7 +6,7 @@ jobs:
     name: Runs e2e tests with Playwright
     steps:
     - name: Playwright test suite
-      uses: SophieDeBenedetto/playwright-test-service-prototype@v1.14
+      uses: jclem/playwright-test-service-prototype@master
     - name: upload artifacts
       if: ${{ always() }} # could be if: ${{ failure() }} to only upload artifacts when previous step of running playwright tests fails
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
For the particular needs of this action, I think the Docker CLI will work better than building a Docker action.

This PR:

- Manually pulls the Docker container
- Creates an output directory that will be mounted in the container
- Runs the container with the mounted output directory
- Uploads artifacts from the output directory

Note that you'll want to build and push a Docker container from https://github.com/SophieDeBenedetto/playwright-test-service-prototype/pull/2 in order for this to work. The workflow assumes the container is called/tagged `SophieDeBenedetto/playwright-test-service-prototype:latest`.